### PR TITLE
画面遷移実装

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.kotlin.compose)
     id("com.google.android.libraries.mapsplatform.secrets-gradle-plugin")
     id("kotlin-kapt")
+    id("com.google.dagger.hilt.android")
 }
 
 // local.propertiesの読み込み (APIキーを読み取る)
@@ -66,6 +67,9 @@ dependencies {
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.navigation.runtime.ktx)
     implementation(libs.androidx.compose.foundation.layout)
+    // Navigation Compose
+    implementation("androidx.navigation:navigation-compose:2.7.7")
+    
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
@@ -88,4 +92,6 @@ dependencies {
     //Coil
     implementation("io.coil-kt:coil:2.6.0")
     implementation("io.coil-kt:coil-compose:2.6.0")
+    //HttpLoggingInterceptor
+    implementation("com.squareup.okhttp3:logging-interceptor:4.12.0")
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <application
+        android:name=".FoodAppApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/example/food_app/FoodAppApplication.kt
+++ b/app/src/main/java/com/example/food_app/FoodAppApplication.kt
@@ -1,0 +1,7 @@
+package com.example.food_app
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+@HiltAndroidApp
+class FoodAppApplication : Application()

--- a/app/src/main/java/com/example/food_app/data/model/GourmetResponse.kt
+++ b/app/src/main/java/com/example/food_app/data/model/GourmetResponse.kt
@@ -14,7 +14,7 @@ data class Results(
     @SerialName("results_available") val results_available: Int,
     @SerialName("results_returned") val results_returned: Int,
     @SerialName("results_start") val results_start: Int,
-    val shop: List<Shop>
+    val shop: List<Shop> = emptyList() // shopがない場合も考慮
 )
 
 //お店の詳細情報リスト
@@ -33,6 +33,8 @@ data class Shop(
     val `catch`: String,
     val capacity: Int,
     val access: String,
+    val other_memo: String = "",
+    val parking: String = "",
     @SerialName("mobile_access") val mobileAccess: String,
     val urls: Urls,
     val photo: Photo,

--- a/app/src/main/java/com/example/food_app/di/NetworkModule.kt
+++ b/app/src/main/java/com/example/food_app/di/NetworkModule.kt
@@ -1,0 +1,36 @@
+package com.example.food_app.di
+
+import com.example.food_app.interfaces.JsonPlaceHolder
+import com.google.gson.GsonBuilder
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class) // アプリ全体で使えるようにする
+object NetworkModule {
+
+    @Provides
+    @Singleton
+    fun provideRetrofit(): Retrofit {
+        // Gsonの設定
+        val gson = GsonBuilder()
+            .setLenient() // HTMLなどが返ってきた時のパースエラーを少し緩和する設定
+            .create()
+
+        return Retrofit.Builder()
+            .baseUrl("https://webservice.recruit.co.jp/hotpepper/")
+            .addConverterFactory(GsonConverterFactory.create(gson))
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideJsonPlaceHolder(retrofit: Retrofit): JsonPlaceHolder {
+        return retrofit.create(JsonPlaceHolder::class.java)
+    }
+}

--- a/app/src/main/java/com/example/food_app/ui/detail/DetailScreen.kt
+++ b/app/src/main/java/com/example/food_app/ui/detail/DetailScreen.kt
@@ -107,10 +107,13 @@ fun ShopDetailContent(shop: Shop) {
                 fontWeight = FontWeight.Bold
             )
             Spacer(modifier = Modifier.height(8.dp))
-            Text("サンプルサンプルサンプルサンプル")
-            Text("・サンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプル")
-            Text("・サンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプル")
-            Text("・サンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプル")
+            DetailItem(title = "ジャンル", content = shop.genre.name)
+            DetailItem(title = "予算", content = shop.budget.name)
+            DetailItem(title = "席数", content = shop.capacity.toString())
+            DetailItem(title = "携帯アクセス", content = shop.mobileAccess ?:"情報なし")
+            DetailItem(title = "ホームページ", content = shop.urls.pc ?:"情報なし")
+            DetailItem(title = "駐車場", content = shop.parking ?:"情報なし")
+            DetailItem(title = "その他メモ", content = shop.other_memo ?:"情報なし")
         }
     }
 }
@@ -157,7 +160,9 @@ fun DetailScreenPreview() {
             mobile = MobilePhoto("https://imgfp.hotp.jp/IMGH/28/83/P034812883/P034812883_168.jpg", "https://imgfp.hotp.jp/IMGH/28/83/P034812883/P034812883_100.jpg")
         ),
         open = "月～金: 17:00～23:00\n土日祝: 12:00～23:00",
-        close = "年中無休"
+        close = "年中無休",
+        parking = "なし",
+        other_memo = "特になし"
     )
 
     MaterialTheme {

--- a/app/src/main/java/com/example/food_app/ui/result/ResultScreen.kt
+++ b/app/src/main/java/com/example/food_app/ui/result/ResultScreen.kt
@@ -196,7 +196,9 @@ fun ResultScreenPreview() {
                 urls = Urls("http://example.com"),
                 photo = Photo(PcPhoto("", "", ""), MobilePhoto("", "")),
                 open = "17:00-23:00",
-                close = "年中無休"
+                close = "年中無休",
+                parking = "なし",
+                other_memo = "特になし"
             )
             return GourmetResponse(
                 Results(

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
+    id("com.google.dagger.hilt.android") version "2.51.1" apply false
 }
 buildscript {
     dependencies {


### PR DESCRIPTION
close #9 
検索画面 → 検索結果画面 → 店舗詳細画面の画面遷移を実装
APIから取得したデータが正しく表示されることを確認
検索画面のDropDownMenuも正常に動作
APIから取得するデータに駐車場情報、メモを追加し、それぞれ店舗詳細画面に表示させる

<img width="360" height="2400" alt="Screenshot_20251121_144207" src="https://github.com/user-attachments/assets/d9c94cd8-47bb-4e5a-ba70-71d3903563ac" />
<img width="360" height="2400" alt="Screenshot_20251121_144247" src="https://github.com/user-attachments/assets/a813bcd2-6cfa-4306-b119-63baea43725b" />
<img width="360" height="2400" alt="Screenshot_20251121_144352" src="https://github.com/user-attachments/assets/822e6208-753e-44c5-ab7d-43ddedd033d9" />
<img width="360" height="2400" alt="Screenshot_20251121_144404" src="https://github.com/user-attachments/assets/25e302d9-c0a0-4604-a351-f926e1e04429" />


